### PR TITLE
Fixed file extension reading.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -42,7 +42,7 @@ class SJ {
      */
     parse(filePath, configPath = "") {
         // Make sure our file is a SJ file
-        if (filePath.split(".")[1] !== "sj")
+        if (filePath.split(".").reverse()[0] !== "sj")
             throw new Error('The provided file MUST be a SJ file.');
         let parsedSJ = "";
         let contents = readFileSync(filePath, { encoding: "utf-8" }).toString().split("\n");

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -48,7 +48,7 @@ class SJ {
      */
     public parse(filePath: string, configPath = ""): string {
         // Make sure our file is a SJ file
-        if (filePath.split(".")[1] !== "sj") throw new Error('The provided file MUST be a SJ file.');
+        if (filePath.split(".").reverse()[0] !== "sj") throw new Error('The provided file MUST be a SJ file.');
         let parsedSJ:string = "";
         let contents = readFileSync(filePath, {encoding: "utf-8"}).toString().split("\n");
         let i = 1; // The current line we are on


### PR DESCRIPTION
When checking a file extension with `.split` you need to be careful for when file names are longer, such as `config.mainModule.sj` because checking that with the **current** check will return `split(".")[1]` as `mainModule` instead of `sj` as `sj` is in the 2nd array position, rather than the first (`[1]`).

By reversing the array, you are given `config.mainModule.sj` with `.split(".").reverse()[0]` which splits it into `["config", "mainModule", "sj"]` and reversing gives you `["sj", "mainModule", "config"]` so you can always call the `[0]` position in the array and pull the last element of the file name, which will now always be the extension.

This generally just allows more variety and safer checking in file names.